### PR TITLE
Improve downstream header diagnostics and login payload

### DIFF
--- a/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
+++ b/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sepidar.Extension.Services;
@@ -42,7 +43,10 @@ public class SepidarHeadersHandler : DelegatingHandler
         if (requiresSession && (!_cache.TryGet<SepidarSession>("Sepidar:Session", out session) || session is null))
         {
             _logger.LogWarning("Sepidar session not found for downstream request {Method} {Path}.", request.Method, normalizedPath);
-            var content = new StringContent(JsonSerializer.Serialize(new { message = "ابتدا دستگاه را رجیستر و لاگین کنید." }));
+            var content = new StringContent(
+                JsonSerializer.Serialize(new { message = "ابتدا دستگاه را رجیستر و لاگین کنید." }),
+                Encoding.UTF8,
+                "application/json");
             var resp = new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = content };
             return resp;
         }
@@ -54,7 +58,10 @@ public class SepidarHeadersHandler : DelegatingHandler
             if (!TryBuildRsaParams(session!, out var rsaParams))
             {
                 _logger.LogWarning("Failed to build RSA parameters from cached session for downstream request {Method} {Path}.", request.Method, normalizedPath);
-                var content = new StringContent(JsonSerializer.Serialize(new { message = "کلید عمومی نامعتبر است. رجیستر را بررسی کنید." }));
+                var content = new StringContent(
+                    JsonSerializer.Serialize(new { message = "کلید عمومی نامعتبر است. رجیستر را بررسی کنید." }),
+                    Encoding.UTF8,
+                    "application/json");
                 return new HttpResponseMessage(HttpStatusCode.BadGateway) { Content = content };
             }
 

--- a/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
+++ b/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Sepidar.Extension.Services;
 using SepidarGateway.Api.Interfaces;
 using SepidarGateway.Api.Models;
@@ -12,15 +14,19 @@ public class SepidarHeadersHandler : DelegatingHandler
 {
     private readonly ICacheService _cache;
     private readonly PublicKeyProcessor _pk;
+    private readonly ILogger<SepidarHeadersHandler> _logger;
+    private readonly ICurlBuilder _curlBuilder;
     private static readonly HashSet<string> _noSessionPaths = new(StringComparer.OrdinalIgnoreCase)
     {
         "/v1/api/General/GenerationVersion"
     };
 
-    public SepidarHeadersHandler(ICacheService cache)
+    public SepidarHeadersHandler(ICacheService cache, ILogger<SepidarHeadersHandler> logger, ICurlBuilder curlBuilder)
     {
         _cache = cache;
         _pk = new PublicKeyProcessor();
+        _logger = logger;
+        _curlBuilder = curlBuilder;
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -34,6 +40,7 @@ public class SepidarHeadersHandler : DelegatingHandler
         SepidarSession? session = null;
         if (requiresSession && (!_cache.TryGet<SepidarSession>("Sepidar:Session", out session) || session is null))
         {
+            _logger.LogWarning("Sepidar session not found for downstream request {Method} {Path}.", request.Method, normalizedPath);
             var content = new StringContent(JsonSerializer.Serialize(new { message = "ابتدا دستگاه را رجیستر و لاگین کنید." }));
             var resp = new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = content };
             return resp;
@@ -45,6 +52,7 @@ public class SepidarHeadersHandler : DelegatingHandler
             var arbitrary = Guid.NewGuid();
             if (!TryBuildRsaParams(session!, out var rsaParams))
             {
+                _logger.LogWarning("Failed to build RSA parameters from cached session for downstream request {Method} {Path}.", request.Method, normalizedPath);
                 var content = new StringContent(JsonSerializer.Serialize(new { message = "کلید عمومی نامعتبر است. رجیستر را بررسی کنید." }));
                 return new HttpResponseMessage(HttpStatusCode.BadGateway) { Content = content };
             }
@@ -65,7 +73,10 @@ public class SepidarHeadersHandler : DelegatingHandler
                 request.Headers.Remove("Authorization");
                 request.Headers.Add("Authorization", session!.Authorization!);
             }
+            _logger.LogInformation("Injected Sepidar headers for downstream request {Method} {Path}.", request.Method, normalizedPath);
         }
+
+        await LogDownstreamCurlAsync(request, cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
@@ -108,5 +119,63 @@ public class SepidarHeadersHandler : DelegatingHandler
     {
         if (string.IsNullOrWhiteSpace(path)) return string.Empty;
         return path.TrimEnd('/');
+    }
+
+    private async Task LogDownstreamCurlAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!_logger.IsEnabled(LogLevel.Information)) return;
+
+        try
+        {
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var header in request.Headers)
+            {
+                headers[header.Key] = string.Join(", ", header.Value);
+            }
+            if (request.Content?.Headers is not null)
+            {
+                foreach (var header in request.Content.Headers)
+                {
+                    headers[header.Key] = string.Join(", ", header.Value);
+                }
+            }
+
+            if (headers.TryGetValue("Authorization", out var auth) && !string.IsNullOrWhiteSpace(auth))
+            {
+                headers["Authorization"] = MaskAuthorization(auth);
+            }
+
+            string? bodyJson = null;
+            if (request.Content is StringContent stringContent)
+            {
+                bodyJson = await stringContent.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var uri = request.RequestUri?.ToString() ?? string.Empty;
+            var curl = _curlBuilder.Build(uri, headers, bodyJson, request.Method);
+            _logger.LogInformation("Downstream curl ready: {Curl}", curl);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to log downstream curl request.");
+        }
+    }
+
+    private static string MaskAuthorization(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return value;
+        const string bearerPrefix = "Bearer ";
+        if (value.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var token = value[bearerPrefix.Length..];
+            if (token.Length <= 4)
+            {
+                return bearerPrefix + "***";
+            }
+            return bearerPrefix + token[..4] + "...";
+        }
+
+        if (value.Length <= 6) return "***";
+        return value[..3] + "...";
     }
 }

--- a/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
+++ b/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
@@ -19,7 +19,8 @@ public class SepidarHeadersHandler : DelegatingHandler
     private readonly ICurlBuilder _curlBuilder;
     private static readonly HashSet<string> _noSessionPaths = new(StringComparer.OrdinalIgnoreCase)
     {
-        "/v1/api/General/GenerationVersion"
+        "/v1/api/General/GenerationVersion",
+        "/api/General/GenerationVersion"
     };
 
     public SepidarHeadersHandler(ICacheService cache, ILogger<SepidarHeadersHandler> logger, ICurlBuilder curlBuilder)

--- a/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
+++ b/GatewayAsDevice.Api/Handlers/SepidarHeadersHandler.cs
@@ -36,6 +36,7 @@ public class SepidarHeadersHandler : DelegatingHandler
         var normalizedPath = NormalizePath(rawPath);
 
         var requiresSession = !_noSessionPaths.Contains(normalizedPath);
+        _logger.LogInformation("SepidarHeadersHandler executing for {Method} {Path}. Requires session: {RequiresSession}", request.Method, normalizedPath, requiresSession);
 
         SepidarSession? session = null;
         if (requiresSession && (!_cache.TryGet<SepidarSession>("Sepidar:Session", out session) || session is null))

--- a/GatewayAsDevice.Api/Program.cs
+++ b/GatewayAsDevice.Api/Program.cs
@@ -10,8 +10,6 @@ using SepidarGateway.Api.Endpoints.Gateway;
 using SepidarGateway.Api.Endpoints.Device;
 using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
-using SepidarGateway.Api.Interfaces;
-using SepidarGateway.Api.Services;
 using SepidarGateway.Api.Handlers;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -63,7 +61,7 @@ builder.Services.AddSingleton<ICacheService, CacheService>();
 builder.Services.AddTransient<SepidarHeadersHandler>();
 builder.Services
     .AddOcelot()
-    .AddDelegatingHandler<SepidarHeadersHandler>();
+    .AddDelegatingHandler<SepidarHeadersHandler>(true);
 
 var app = builder.Build();
 

--- a/GatewayAsDevice.Api/Program.cs
+++ b/GatewayAsDevice.Api/Program.cs
@@ -61,7 +61,9 @@ builder.Services.AddSingleton<ICurlBuilder, CurlBuilder>();
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ICacheService, CacheService>();
 builder.Services.AddTransient<SepidarHeadersHandler>();
-builder.Services.AddOcelot();
+builder.Services
+    .AddOcelot()
+    .AddDelegatingHandler<SepidarHeadersHandler>();
 
 var app = builder.Build();
 

--- a/GatewayAsDevice.Api/Services/CurlBuilder.cs
+++ b/GatewayAsDevice.Api/Services/CurlBuilder.cs
@@ -17,6 +17,7 @@ public class CurlBuilder : ICurlBuilder
     public string Build(string url, IDictionary<string, string>? headers = null, string? bodyJson = null, HttpMethod? method = null)
     {
         method ??= HttpMethod.Post;
+        var methodName = method.Method.ToUpperInvariant();
         var ps = _nextPowerShell;
         _nextPowerShell = false; // reset
 
@@ -24,7 +25,12 @@ public class CurlBuilder : ICurlBuilder
         {
             static string Q(string s) => "\"" + s.Replace("`", "``").Replace("\"", "`\"") + "\"";
             var sb = new StringBuilder();
-            sb.Append("curl --location ").Append(Q(url));
+            sb.Append("curl --location");
+            if (!string.IsNullOrWhiteSpace(methodName))
+            {
+                sb.Append(' ').Append("--request ").Append(methodName);
+            }
+            sb.Append(' ').Append(Q(url));
             if (headers is not null)
             {
                 foreach (var (k, v) in headers)
@@ -42,7 +48,12 @@ public class CurlBuilder : ICurlBuilder
         {
             static string Q(string s) => "'" + s.Replace("'", "'\"'\"'") + "'";
             var sb = new StringBuilder();
-            sb.Append("curl --location ").Append(Q(url));
+            sb.Append("curl --location");
+            if (!string.IsNullOrWhiteSpace(methodName))
+            {
+                sb.Append(' ').Append("--request ").Append(methodName);
+            }
+            sb.Append(' ').Append(Q(url));
             if (headers is not null)
             {
                 foreach (var (k, v) in headers)

--- a/GatewayAsDevice.Api/Services/CurlBuilder.cs
+++ b/GatewayAsDevice.Api/Services/CurlBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 using System.Text;
 using SepidarGateway.Api.Interfaces;
 

--- a/GatewayAsDevice.Api/ocelot.json
+++ b/GatewayAsDevice.Api/ocelot.json
@@ -12,9 +12,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -29,9 +26,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -46,9 +40,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -63,9 +54,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -80,9 +68,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -97,9 +82,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -114,9 +96,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -131,9 +110,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -148,9 +124,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -165,9 +138,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -182,9 +152,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -199,9 +166,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -216,9 +180,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -233,9 +194,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -250,9 +208,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -267,9 +222,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -284,9 +236,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -301,9 +250,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -318,9 +264,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -335,9 +278,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -352,9 +292,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -369,9 +306,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -386,9 +320,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -403,9 +334,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -420,9 +348,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -437,9 +362,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -454,9 +376,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -471,9 +390,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -488,9 +404,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -505,9 +418,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -522,9 +432,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -539,9 +446,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -556,9 +460,6 @@
           "Host": "178.131.66.32",
           "Port": 7373
         }
-      ],
-      "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     }
   ],

--- a/GatewayAsDevice.Api/ocelot.json
+++ b/GatewayAsDevice.Api/ocelot.json
@@ -14,7 +14,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -31,7 +31,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -48,7 +48,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -65,7 +65,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -82,7 +82,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -99,7 +99,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -116,7 +116,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -133,7 +133,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -150,7 +150,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -167,7 +167,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -184,7 +184,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -201,7 +201,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -218,7 +218,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -235,7 +235,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -252,7 +252,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -269,7 +269,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -286,7 +286,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -303,7 +303,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -320,7 +320,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -337,7 +337,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -354,7 +354,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -371,7 +371,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -388,7 +388,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -405,7 +405,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -422,7 +422,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -439,7 +439,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -456,7 +456,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -473,7 +473,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -490,7 +490,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -507,7 +507,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -524,7 +524,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -541,7 +541,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     },
     {
@@ -558,7 +558,7 @@
         }
       ],
       "DelegatingHandlers": [
-        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, SepidarGateway.Api"
+        "SepidarGateway.Api.Handlers.SepidarHeadersHandler, GatewayAsDevice.Api"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- remove duplicated IntegrationID and Authorization fields from the Login payload while keeping them promoted at the response root
- harden session persistence by safely extracting identifiers/tokens and update the curl builder so downstream requests include the HTTP method
- inject structured logging for downstream requests that shows sanitized curl commands after headers are applied

## Testing
- `dotnet build GatewayAsDevice.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e015648854832c9ca38c0d2076cd29